### PR TITLE
Preserve all SSH configuration, including host keys, and also preserve Wireguard keys.

### DIFF
--- a/SD_ROOT/wz_mini/usr/bin/upgrade-run.sh
+++ b/SD_ROOT/wz_mini/usr/bin/upgrade-run.sh
@@ -6,7 +6,8 @@ mkdir /opt/Upgrade/preserve
 wget --no-check-certificate https://github.com/gtxaspec/wz_mini_hacks/archive/refs/heads/master.zip -O /opt/Upgrade/wz_mini.zip; sync
 unzip /opt/Upgrade/wz_mini.zip -d /opt/Upgrade/
 cp /opt/wz_mini/wz_mini.conf /opt/Upgrade/preserve/
-cp /opt/wz_mini/etc/ssh/authorized_keys /opt/Upgrade/preserve/
+cp -r /opt/wz_mini/etc/ssh /opt/Upgrade/preserve/
+cp -r /opt/wz_mini/etc/wireguard /opt/Upgrade/preserve/
 sync
 reboot
 }
@@ -22,8 +23,10 @@ mv /opt/Upgrade/wz_mini_hacks-master/SD_ROOT/wz_mini/* /opt/wz_mini/
 rm -f /opt/factory_t31_ZMC6tiIDQN
 mv /opt/Upgrade/wz_mini_hacks-master/SD_ROOT/factory_t31_ZMC6tiIDQN /opt/factory_t31_ZMC6tiIDQN
 
-cp /opt/Upgrade/preserve/authorized_keys  /opt/wz_mini/etc/ssh/
+diff /opt/wz_mini/wz_mini.conf /opt/Upgrade/preserve/wz_mini.conf
 cp /opt/Upgrade/preserve/wz_mini.conf /opt/wz_mini/
+cp /opt/Upgrade/preserve/ssh/*  /opt/wz_mini/etc/ssh/
+cp -r /opt/Upgrade/preserve/wireguard  /opt/wz_mini/etc/
 rm -rf /opt/Upgrade
 sync
 reboot


### PR DESCRIPTION
@gtxaspec tweaks for the upgrade-run.sh script:
* Preserve all SSH configuration, including host keys, not only `authorized_keys`. That way an upgrade does not force a remote user to remove the entry from known_hosts to reconnect w/ SSH
* Preserve Wireguard configuration, so a pre-existing VPN connection can be re-established after an upgrade
* Print out a diff of the "factory" `wz_mini.conf` to the user's version, so they can review any additional settings they may want to customize. Output is captured in `/opt/v3_upgrade.log`

btw, does this also work w/ V2 cameras? Just asking because of the filename, `v3_upgrade.log`.