### PR TITLE
Flipped registers for target/max bitrate on V3

### DIFF
--- a/SD_ROOT/wz_mini/etc/init.d/wz_user.sh
+++ b/SD_ROOT/wz_mini/etc/init.d/wz_user.sh
@@ -406,7 +406,7 @@ if [[ "$RTSP_HI_RES_ENABLED" == "true" ]]; then
 		if [[ "$V2" == "true" ]]; then
 			watch -n30 -t "/system/bin/impdbg --enc_rc_s 0:28:4:$RTSP_LOW_RES_MAX_BITRATE" > /dev/null 2>&1 &
 		else
-			watch -n30 -t "/system/bin/impdbg --enc_rc_s 0:48:4:$RTSP_HI_RES_MAX_BITRATE" > /dev/null 2>&1 &
+			watch -n30 -t "/system/bin/impdbg --enc_rc_s 0:52:4:$RTSP_HI_RES_MAX_BITRATE" > /dev/null 2>&1 &
 		fi
 	fi
 
@@ -414,7 +414,7 @@ if [[ "$RTSP_HI_RES_ENABLED" == "true" ]]; then
 		if [[ "$V2" == "true" ]]; then
 			echo "not supported on v2"
 		else
-			watch -n30 -t "/system/bin/impdbg --enc_rc_s 0:52:4:$RTSP_HI_RES_TARGET_BITRATE" > /dev/null 2>&1 &
+			watch -n30 -t "/system/bin/impdbg --enc_rc_s 0:48:4:$RTSP_HI_RES_TARGET_BITRATE" > /dev/null 2>&1 &
 		fi
 	fi
 
@@ -475,7 +475,7 @@ if [[ "$RTSP_LOW_RES_ENABLED" == "true" ]]; then
 		if [[ "$V2" == "true" ]]; then
 			watch -n30 -t "/system/bin/impdbg --enc_rc_s 1:28:4:$RTSP_LOW_RES_MAX_BITRATE" > /dev/null 2>&1 &
 		else
-			watch -n30 -t "/system/bin/impdbg --enc_rc_s 1:48:4:$RTSP_LOW_RES_MAX_BITRATE" > /dev/null 2>&1 &
+			watch -n30 -t "/system/bin/impdbg --enc_rc_s 1:52:4:$RTSP_LOW_RES_MAX_BITRATE" > /dev/null 2>&1 &
 		fi
 	fi
 
@@ -483,7 +483,7 @@ if [[ "$RTSP_LOW_RES_ENABLED" == "true" ]]; then
 		if [[ "$V2" == "true" ]]; then
 			echo "not supported on v2"
 		else
-			watch -n30 -t "/system/bin/impdbg --enc_rc_s 1:52:4:$RTSP_LOW_RES_TARGET_BITRATE" > /dev/null 2>&1 &
+			watch -n30 -t "/system/bin/impdbg --enc_rc_s 1:48:4:$RTSP_LOW_RES_TARGET_BITRATE" > /dev/null 2>&1 &
 		fi
 	fi
 


### PR DESCRIPTION
@gtxaspec looking at the output of `impdb --enc_info`:
```
chnAttr->rcAttr->CappedQuality->uTargetBitRate = 720(0x2d0) offset:size = 48:4
chnAttr->rcAttr->CappedQuality->uMaxBitRate = 960(0x3c0) offset:size = 52:4
```

The correct register for target is 48 and max bitrate is 52.

This PR updated `wz_user.sh` to match that for the V3.