### PR TITLE
Start adding support for Bonding Ethernet and Wifi

### DIFF
--- a/SD_ROOT/wz_mini/etc/init.d/wz_user.sh
+++ b/SD_ROOT/wz_mini/etc/init.d/wz_user.sh
@@ -63,19 +63,39 @@ wait_wlan() {
 rename_interface() {
 ##Fool iCamera by renaming the hardline interface to wlan0
 	echo "renaming interfaces"
+
+	# Bring all interfaces down
 	ifconfig $1 down
 	ifconfig wlan0 down
-        /opt/wz_mini/bin/busybox ip link set wlan0 name wlanold
-        /opt/wz_mini/bin/busybox ip addr flush dev wlanold
-        /opt/wz_mini/bin/busybox ip link set $1 name wlan0
+	ifconfig bond0 down
+
+	# Rename the real wlan0 interface
+	/opt/wz_mini/bin/busybox ip link set wlan0 name wlanold
+	/opt/wz_mini/bin/busybox ip addr flush dev wlanold
+
+	# Have to bring bond0 up to be able to bond our slaves.
+	/opt/wz_mini/bin/busybox ip link set bond0 up
+
+	# Enslave the Ethernet and Original Wifi interfaces
+	# under the Bonding interface.
+	/opt/wz_mini/tmp/.bin/ifenslave bond0 eth0 wlanold
+
+	# Have to bring bond0 down to be rename the interface
+	/opt/wz_mini/bin/busybox ip link set bond0 down
+
+	# Name the bond0 interface to be the "new" wlan0 interface
+	/opt/wz_mini/bin/busybox ip link set bond0 name wlan0
+
+	# Bring the newly renamed wlan0 back up
 	eth_wlan_up
 }
 
 eth_wlan_up() {
 ##Run DHCP client, and bind mount our fake wpa_cli.sh to fool iCamera
-        ifconfig wlan0 up
+	ifconfig wlan0 up
+
 	pkill udhcpc
-        udhcpc -i wlan0 -x hostname:$HOSTNAME -p /var/run/udhcpc.pid -b
+	udhcpc -i wlan0 -x hostname:$HOSTNAME -p /var/run/udhcpc.pid -b
 	if [[ "$V2" == "true" ]]; then
         mount -o bind /opt/wz_mini/bin/wpa_cli.sh /system/bin/wpa_cli
 	else
@@ -223,6 +243,9 @@ if [[ "$ENABLE_USB_ETH" == "true" ]]; then
 	do
 	insmod $KMOD_PATH/kernel/drivers/net/usb/$i.ko
 	done
+
+	# Insert the bonding driver when running Ethernet
+	insmod $KMOD_PATH/kernel/drivers/net/bonding.ko mode=active-backup miimon=100 downdelay=5000 updelay=5000 primary=eth0
 
 	swap_enable
 


### PR DESCRIPTION
NOTE: This is NOT complete yet!

This patch adds support for Bonding the Ethernet and Wifi interfaces as an "active-backup".
(It will default to using the Ethernet interface first, and if disconnected for some reason, will fall back to Wifi)

NOTE: The Ethernet works fine, and when disconnected, Wifi is attempted to be called.
However, when it attempts to flip over to Wifi, it can't, because it does not have the wpa_supplicant info to do it.

I am unfamiliar with how wpa_supplicant works, so it is unclear to me how to feed the /tmp/wpa_supplicant.conf file
to the Wifi interface properly.
I am hoping someone more familiar with it, will be able to run with this.

Below is an example of what we see when the Ethernet cable is connected, disconnected, reconnected:

[  461.155016] bonding: wlan0: link status down for active interface eth0, disabling it in 5000 ms.
[  466.155060] bonding: wlan0: link status definitely down for interface eth0, disabling it
[  466.163594] bonding: wlan0: now running without any active interface !
[  507.040168] asix 1-1:1.0 eth0: link up, 10Mbps, half-duplex, lpa 0x0000
[  507.075075] bonding: wlan0: link status up for interface eth0, enabling it in 0 ms.
[  507.093796] bonding: wlan0: link status definitely up for interface eth0, 10 Mbps half duplex.
[  507.102779] bonding: wlan0: making interface eth0 the new active one.
[  507.115347] bonding: wlan0: first active interface up!

