### PR TITLE
Added auto bind feature for offline / cloud-less setup

### DIFF
--- a/SD_ROOT/wz_mini/etc/init.d/S20initsetup
+++ b/SD_ROOT/wz_mini/etc/init.d/S20initsetup
@@ -1,0 +1,46 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:
+# Short-Description: Setup bindOk=1 once WiFi settings are detected.
+# Description:       Update .user_config so bindOk=1 when QR code containing WiFi settings are scanned. Allows for WiFi to work on next reboot without needing Wyze App/Cloud initial setup.
+### END INIT INFO
+
+. /opt/wz_mini/wz_mini.conf
+
+case "$1" in
+	start)
+
+		echo "#####$(basename "$0")#####"
+		
+		if [[ "$ENABLE_AUTO_BIND" != "true" ]] ; then
+			exit 0
+		fi
+
+		# If autobind is enabled, we will set bindOk=1 when WiFi configs are detected.
+		if grep -q bindOk=1 /configs/.user_config ; then
+			echo "Initial setup is done. Nothing to do."
+			exit 0
+		fi
+
+		echo "Initial setup not completed yet."
+
+		while true ; do
+			if [ -f /configs/.wifipasswd ] && [ -s /configs/.wifipasswd ] && [ -f /configs/.wifissid ] && [ -s /configs/.wifissid ] ; then
+				echo "Detected WiFi configs. Updating bindOk=1."
+				sed -i 's/bindOk=0/bindOk=1/g' /configs/.user_config
+
+				grep bindOk /configs/.user_config
+				exit 0
+			fi
+
+			echo "Waiting for WiFi settings from QR code..."
+			sleep 5
+		done &
+		
+		;;
+	*)
+		echo "Usage: $0 {start}"
+		exit 1
+		;;
+esac
+

--- a/SD_ROOT/wz_mini/etc/init.d/S20initsetup
+++ b/SD_ROOT/wz_mini/etc/init.d/S20initsetup
@@ -1,7 +1,7 @@
 #!/bin/sh
 ### BEGIN INIT INFO
 # Provides:
-# Short-Description: Setup bindOk=1 once WiFi settings are detected.
+# Short-Description: Setup bindOk=1 once WiFi settings are detected when in self-hosted mode
 # Description:       Update .user_config so bindOk=1 when QR code containing WiFi settings are scanned. Allows for WiFi to work on next reboot without needing Wyze App/Cloud initial setup.
 ### END INIT INFO
 
@@ -13,7 +13,7 @@ case "$1" in
 		echo "#####$(basename "$0")#####"
 		
 		# If not enabled or on T20 which is unsupported by this script
-		if [[ "$ENABLE_AUTO_BIND" != "true" ]] || [ ! -f /opt/wz_mini/tmp/.T31 ]; then
+		if [[ "$ENABLE_SELFHOSTED_MODE" != "true" ]] || [ ! -f /opt/wz_mini/tmp/.T31 ]; then
 			exit 0
 		fi
 

--- a/SD_ROOT/wz_mini/etc/init.d/S20initsetup
+++ b/SD_ROOT/wz_mini/etc/init.d/S20initsetup
@@ -26,11 +26,16 @@ case "$1" in
 
 		while true ; do
 			if [ -f /configs/.wifipasswd ] && [ -s /configs/.wifipasswd ] && [ -f /configs/.wifissid ] && [ -s /configs/.wifissid ] ; then
-				echo "Detected WiFi configs. Updating bindOk=1."
-				sed -i 's/bindOk=0/bindOk=1/g' /configs/.user_config
+				echo "Detected WiFi configs. "
+				if wpa_cli -p /var/run/wpa_supplicant -i wlan0 STATUS | grep -q wpa_state=COMPLETED ; then
+					echo "WiFi connection seems Good. Updating bindOk=1."
+					sed -i 's/bindOk=0/bindOk=1/g' /configs/.user_config
 
-				grep bindOk /configs/.user_config
-				exit 0
+					/opt/wz_mini/bin/cmd aplay /usr/share/notify/CN/connect_wifi_ok.wav 60
+
+					grep bindOk /configs/.user_config
+					exit 0
+				fi
 			fi
 
 			echo "Waiting for WiFi settings from QR code..."

--- a/SD_ROOT/wz_mini/etc/init.d/S20initsetup
+++ b/SD_ROOT/wz_mini/etc/init.d/S20initsetup
@@ -12,18 +12,34 @@ case "$1" in
 
 		echo "#####$(basename "$0")#####"
 		
-		if [[ "$ENABLE_AUTO_BIND" != "true" ]] ; then
+		# If not enabled or on T20 which is unsupported by this script
+		if [[ "$ENABLE_AUTO_BIND" != "true" ]] || [ ! -f /opt/wz_mini/tmp/.T31 ]; then
 			exit 0
 		fi
 
-		# If autobind is enabled, we will set bindOk=1 when WiFi configs are detected.
-		if grep -q bindOk=1 /configs/.user_config ; then
-			echo "Initial setup is done. Nothing to do."
-			exit 0
+		# Note: At the time of this boot stage, /configs isn't mounted. If it's not mounted, we have to mount it to check the wifi status
+		if mount | grep -q /configs ; then
+			# Is it already set?
+			if grep -q bindOk=1 /configs/.user_config ; then
+				echo "Initial setup is done. Nothing to do."
+				exit 0
+			fi
+		else
+			mount -t jffs2 /dev/mtdblock6 /configs
+
+			# Is it already set?
+			if grep -q bindOk=1 /configs/.user_config ; then
+				echo "Initial setup is done. Nothing to do."
+				exit 0
+			fi
+
+			umount /configs
 		fi
 
 		echo "Initial setup not completed yet."
 
+		# Wait until these wifi settings are set in /configs later on.
+		# Note that /configs will be mounted eventually by the second stage boot.
 		while true ; do
 			if [ -f /configs/.wifipasswd ] && [ -s /configs/.wifipasswd ] && [ -f /configs/.wifissid ] && [ -s /configs/.wifissid ] ; then
 				echo "Detected WiFi configs. "

--- a/SD_ROOT/wz_mini/etc/wz_mini.conf.dist
+++ b/SD_ROOT/wz_mini/etc/wz_mini.conf.dist
@@ -96,7 +96,7 @@ ENABLE_FSCK_ON_BOOT="false"
 ENABLE_CAR_DRIVER="false"
 ENABLE_LOCAL_DNS="false"
 ENABLE_CRONTAB="false"
-ENABLE_AUTO_BIND="false"
+ENABLE_SELFHOSTED_MODE="true"
 
 #####DEBUG#####
 #drops you to a shell via serial, doesn't load app_init.sh

--- a/SD_ROOT/wz_mini/etc/wz_mini.conf.dist
+++ b/SD_ROOT/wz_mini/etc/wz_mini.conf.dist
@@ -96,7 +96,7 @@ ENABLE_FSCK_ON_BOOT="false"
 ENABLE_CAR_DRIVER="false"
 ENABLE_LOCAL_DNS="false"
 ENABLE_CRONTAB="false"
-ENABLE_SELFHOSTED_MODE="true"
+ENABLE_SELFHOSTED_MODE="false"
 
 #####DEBUG#####
 #drops you to a shell via serial, doesn't load app_init.sh

--- a/SD_ROOT/wz_mini/etc/wz_mini.conf.dist
+++ b/SD_ROOT/wz_mini/etc/wz_mini.conf.dist
@@ -96,6 +96,7 @@ ENABLE_FSCK_ON_BOOT="false"
 ENABLE_CAR_DRIVER="false"
 ENABLE_LOCAL_DNS="false"
 ENABLE_CRONTAB="false"
+ENABLE_AUTO_BIND="false"
 
 #####DEBUG#####
 #drops you to a shell via serial, doesn't load app_init.sh

--- a/SD_ROOT/wz_mini/wz_mini.conf
+++ b/SD_ROOT/wz_mini/wz_mini.conf
@@ -96,7 +96,7 @@ ENABLE_FSCK_ON_BOOT="false"
 ENABLE_CAR_DRIVER="false"
 ENABLE_LOCAL_DNS="false"
 ENABLE_CRONTAB="false"
-ENABLE_AUTO_BIND="false"
+ENABLE_SELFHOSTED_MODE="true"
 
 #####DEBUG#####
 #drops you to a shell via serial, doesn't load app_init.sh

--- a/SD_ROOT/wz_mini/wz_mini.conf
+++ b/SD_ROOT/wz_mini/wz_mini.conf
@@ -96,7 +96,7 @@ ENABLE_FSCK_ON_BOOT="false"
 ENABLE_CAR_DRIVER="false"
 ENABLE_LOCAL_DNS="false"
 ENABLE_CRONTAB="false"
-ENABLE_SELFHOSTED_MODE="true"
+ENABLE_SELFHOSTED_MODE="false"
 
 #####DEBUG#####
 #drops you to a shell via serial, doesn't load app_init.sh

--- a/SD_ROOT/wz_mini/wz_mini.conf
+++ b/SD_ROOT/wz_mini/wz_mini.conf
@@ -96,6 +96,7 @@ ENABLE_FSCK_ON_BOOT="false"
 ENABLE_CAR_DRIVER="false"
 ENABLE_LOCAL_DNS="false"
 ENABLE_CRONTAB="false"
+ENABLE_AUTO_BIND="false"
 
 #####DEBUG#####
 #drops you to a shell via serial, doesn't load app_init.sh


### PR DESCRIPTION
This pull request will allow the user to set up the Wyze Cam to automatically reconnect to a WiFi network on reboot without needing the Wyze App. 

**Background**
After pressing the SETUP button on the unit, the device will wipe all existing WiFi settings from the device and will then wait for a QR code to be presented. Once a valid QR code with the WiFi configs is presented, it will write the SSID/password to `/configs`. However, the device will not automatically reconnect back to this network after a reboot because the `bindOk` value in `/configs/.user_config` remains set to `0`. Normally, this value is set to `1` as part of the final setup process involving the Wyze cloud. In situations where the Wyze Cam is placed on air-gapped networks or when the user does not want to use the Wyze App, this does not happen and is where this pull request comes in.

This PR features a startup script that will start when no WiFi configs are defined in `/configs` and when `ENABLE_SELFHOSTED_MODE` is set to `true`.  When the user scans the WiFi configs, it will set `bindOk=1` before terminating and allow the device to reconnect back to the network after a reboot.

**Test**
I tested this using the following steps:
1. On a Wyze Cam v3, press the 'Setup' button to wipe all WiFi configs
2. Load a clean SD card with wz_mini and configure it to ENABLE_SELFHOSTED_MODE=true
3. Insert the SD card and power on the camera
4. Scan the WiFi QR code
5. Verify that the camera is connected to the network (ping it)
6. Power-cycle the camera
7. Verify that the camera can reconnect to the network.