### PR TITLE
Fixed configbackup init script not backing up files

### DIFF
--- a/SD_ROOT/wz_mini/etc/init.d/S11configbackup
+++ b/SD_ROOT/wz_mini/etc/init.d/S11configbackup
@@ -35,7 +35,9 @@ case "$1" in
 				echo "Factory configs backup directory present, not backing up again"
 			else
 				echo "Backup /configs"
+				mount -t jffs2 /dev/mtdblock8 /configs
 				cp -R /configs/ /opt/.wz_backup/
+				umount /configs
 			fi
 
 			if [ -d /opt/.wz_backup/params ]; then

--- a/SD_ROOT/wz_mini/etc/init.d/S11configbackup
+++ b/SD_ROOT/wz_mini/etc/init.d/S11configbackup
@@ -25,7 +25,9 @@ case "$1" in
 				echo "Factory configs backup directory present, not backing up again"
 			else
 				echo "Backup /configs"
+				mount -t jffs2 /dev/mtdblock6 /configs
 				cp -R /configs/ /opt/.wz_backup/
+				umount /configs
 			fi
 		elif [ -f /opt/wz_mini/tmp/.T20 ]; then
 			echo "T20 platform backup"
@@ -40,7 +42,9 @@ case "$1" in
 				echo "Factory params backup directory present, not backing up again"
 			else
 				echo "Backup /params"
+				mount -t jffs2 /dev/mtdblock9 /params
 				cp -R /params/ /opt/.wz_backup/
+				umount /params
 			fi
 		fi
 		;;


### PR DESCRIPTION
I found it strange that the config backups on the SD card were always empty.

It turns out, the `/configs` directory isn't mounted at this point in the boot process. As a result this backup doesn't actually work and just copies an empty directory every time.

This PR will mount the `/configs` directory before copying it and then immediately unmount it.

I don't have a T20, so please confirm whether the T20 has a `/configs` directory as well and whether it needs to be mounted.