### PR TITLE
Fixed broken iCamera patch script for Wyze Cam v3

### DIFF
--- a/SD_ROOT/wz_mini/usr/bin/patch_icamera.sh
+++ b/SD_ROOT/wz_mini/usr/bin/patch_icamera.sh
@@ -222,7 +222,7 @@ function patch_wzutil_testconnectbyurl_skip_check() {
 	[ ! -f /opt/wz_mini/tmp/.T20 ]   && return  # Only on the v2
 	[[ "$Version" == "4.61.0.1" ]]   && return
 	[[ "$Version" == "4.36.9.139" ]] && return
-	[[ "$Version" == "4.9.8.1002" ]] || return  # Only supports 4.9.8.1002
+	[[ "$Version" != "4.9.8.1002" ]] && return  # Only supports 4.9.8.1002
 
 	echo -e "\n\n====> Calling ${FUNCNAME[0]}\n"
 
@@ -252,7 +252,7 @@ function patch_wzutil_testconnectbyurl_skip_check() {
 # Applies only to the v2
 function patch_v2_led_connect_led () {
 	# Applies only to this particular firmware in the v2.
-	[[ "$Version" == "4.9.8.1002" ]] || return
+	[[ "$Version" != "4.9.8.1002" ]] && return
 
 	echo -e "\n\n====> Calling ${FUNCNAME[0]}\n"
 


### PR DESCRIPTION
The return code for `false||return` is non-zero, which causes the script to fail when the v2 checks fail.

Tested on my v3 and it seems to apply the patch properly now. 

This PR addresses #314