### PR TITLE
Fixed cron files being incorrectly copied in during upgrade

### DIFF
--- a/SD_ROOT/wz_mini/bin/upgrade-run.sh
+++ b/SD_ROOT/wz_mini/bin/upgrade-run.sh
@@ -159,8 +159,8 @@ cp /opt/Upgrade/preserve/ssh/*  /opt/wz_mini/etc/ssh/
 cp /opt/Upgrade/preserve/configs/*  /opt/wz_mini/etc/configs
 cp -r /opt/Upgrade/preserve/wireguard  /opt/wz_mini/etc/
 cp -r /opt/Upgrade/preserve/rc.local.d  /opt/wz_mini/etc/
-cp -r /opt/Upgrade/preserve/cron /opt/wz_mini/etc/cron
-cp -r /opt/Upgrade/preserve/resolv.dnsmasq /opt/wz_mini/etc/resolv.dnsmasq
+cp /opt/Upgrade/preserve/cron/* /opt/wz_mini/etc/cron/
+cp /opt/Upgrade/preserve/resolv.dnsmasq /opt/wz_mini/etc/resolv.dnsmasq
 
 rm -rf /opt/Upgrade
 sync


### PR DESCRIPTION
The cron directory was being copied into the existing cron directory during the upgrade, resulting in a doubly nested cron directory for every upgrade.

Since the directory exists and only contains flat files, we can just do a non-recurisve copy on all files with a glob.

`resolv.dnsmasq` is also just a file, so we can remove the `-r` option.