### PR TITLE
Use dmon to start NTP in place of timesync if NTP_SERVER is defined

### DIFF
--- a/SD_ROOT/wz_mini/etc/init.d/S18ntp
+++ b/SD_ROOT/wz_mini/etc/init.d/S18ntp
@@ -13,8 +13,8 @@ case "$1" in
 		echo "#####$(basename "$0")#####"
 		
 		if [ ! -z "$NTP_SERVER" ] ; then
-			# Slight delay required so that we can kill timesync from interfering
-			(sleep 30 && kill -9 $(pgrep -f timesync) ; /opt/wz_mini/tmp/.bin/ntpd -p "$NTP_SERVER") &
+			# Replace timesync call with our own ntpd using a custom NTP server
+			sed -i "s/\/system\/bin\/timesync/\/opt\/wz_mini\/tmp\/.bin\/ntpd -ndp '$NTP_SERVER'/" /opt/wz_mini/tmp/.storage/app_init.sh
 		fi
 		
 		;;


### PR DESCRIPTION
My initial PR that introduced the `NTP_SERVER` option used a startup script that kills timsync and then runs ntpd in the background. This is not an elegant solution since it will keep a subshell opened for NTP and log messages from NTP aren't recorded. This PR changes the behavior by swapping timesync with ntpd in the original dmon call in the `app_init.sh` init script.

This PR allows NTP to immediately run instead of timesync when `NTP_SERVER` is defined. NTP will be monitored by dmon (and be restarted if necessary) and benefits from the existing dslog logger to capture any NTP messages.

This has been tested on all my Wyze Cam v3s over the past week with no issues.