### PR TITLE
Kill sinker and hl_client in self-hosted mode

### DIFF
--- a/SD_ROOT/wz_mini/etc/init.d/S21killmisc
+++ b/SD_ROOT/wz_mini/etc/init.d/S21killmisc
@@ -1,0 +1,30 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:
+# Short-Description: Kills unwanted processes in selfhosted mode (sinker and hl_client)
+# Description:       sinker and hl_client phones home. In self-hosted mode, these two processes can be killed to save CPU cycles (and reduce log spam).
+### END INIT INFO
+
+. /opt/wz_mini/wz_mini.conf
+
+case "$1" in
+	start)
+
+		echo "#####$(basename "$0")#####"
+		
+		# If not enabled, quit
+		if [[ "$ENABLE_SELFHOSTED_MODE" != "true" ]] ; then
+			exit 0
+		fi
+
+		# Remove sinker/hl_client lines from the startup script
+		sed -i '/sinker/d' /opt/wz_mini/tmp/.storage/app_init.sh
+		sed -i '/hl_client/d' /opt/wz_mini/tmp/.storage/app_init.sh
+		
+		;;
+	*)
+		echo "Usage: $0 {start}"
+		exit 1
+		;;
+esac
+


### PR DESCRIPTION
In the self hosted mode where internet access is restricted, the sinker and hl_client processes will repeatedly retry to connect to Wyze's servers. This is apparent in the system log messages. To reduce noise and unnecessary DNS lookups, these two processes can be killed when `ENABLE_SELFHOSTED_MODE` is set without any negative side effects.

I believe that hl_client is a MQTT client (hl being hualai) that connects to Wyze's MQTT server. The sinker program seems to be a heartbeat program of some sort (maybe upload/download video sync - ie. _sink?_ - program?)

I've tested with my Wyze Cam v3's for a week with these processes killed with no noticable adverse effects.