### PR TITLE
Improve v2 firmware validation and error checks

### DIFF
--- a/v2_install/.gitignore
+++ b/v2_install/.gitignore
@@ -1,1 +1,2 @@
 demo.bin
+demo*.zip

--- a/v2_install/fw_tool.sh
+++ b/v2_install/fw_tool.sh
@@ -40,7 +40,8 @@ elif [ "$ACTION" = "pack" ]; then
     #need to pad kernel is its smaller than the stock kernel size, 2097152 bytes
     dd if=/dev/zero of=$TMP_DIR/kernel.bin bs=1 count=1 seek=2097151
 
-    cat $TMP_DIR/kernel.bin $TMP_DIR/rootfs.bin $TMP_DIR/driver.bin $TMP_DIR/appfs.bin > $TMP_DIR/flash.bin
+    #only run mkimage if cat succeeds, otherwise it's possible that a bad image is created
+    cat $TMP_DIR/kernel.bin $TMP_DIR/rootfs.bin $TMP_DIR/driver.bin $TMP_DIR/appfs.bin > $TMP_DIR/flash.bin && \
     mkimage -A MIPS -O linux -T firmware -C none -a 0 -e 0 -n jz_fw -d $TMP_DIR/flash.bin $DEMO_OUT
 
 else


### PR DESCRIPTION
To reduce the chance that a bad firmware image is created and used, the following functionality has been implemented:

1. Check md5 sums of local files in addition to downloaded files
2. Copy a backup of the original firmware, instead of removing it
3. Do not make an image unless all parts are present
4. Only output success message if the image file exists

The above fixes an issue where if a provided firmware zipfile is unable to be read, the script continues on, generates a bad demo.bin file, and suggests the file is good for loading into the camera. The above updates help prevent this from occurring

Before This Fix, with an unreadable zipfile (incorrectly indicates the demo.bin is ready to use)
![image](https://user-images.githubusercontent.com/72006/209926379-d0504db2-d532-4ae1-b5e8-f6268e8ca9c1.png)

After This Fix, with an unreadable zipfile (correctly indicates that the provided zipfile firmware isn't usable)
![image](https://user-images.githubusercontent.com/72006/209926574-0822d9a0-469e-4d83-be5c-cfc90fc20ca2.png)

After This Fix, with valid zipfile (correctly indicates that the generated demo.bin is ready to use)
![image](https://user-images.githubusercontent.com/72006/209932526-5df483f1-d383-41a3-9481-0fe5f92ff1ee.png)

