### PR TITLE
jpeg.cgi now compliant with HTTP/1.1 RFC7230 (nodejs/axios compatible)

### DIFF
--- a/SD_ROOT/wz_mini/www/cgi-bin/jpeg.cgi
+++ b/SD_ROOT/wz_mini/www/cgi-bin/jpeg.cgi
@@ -8,7 +8,7 @@ if [[ $REQUEST_METHOD = 'GET' ]]; then
   IFS='&'
   for PAIR in $QUERY_STRING
   do
-      K=$(echo $PAIR | cut -f1 -d=)                                             
+      K=$(echo $PAIR | cut -f1 -d=)
       VA=$(echo $PAIR | cut -f2 -d=)
       #VB=${VA//%3A/:}
       #echo "<div>$K=$VA</div>"
@@ -16,13 +16,13 @@ if [[ $REQUEST_METHOD = 'GET' ]]; then
   done
 fi
 
-if [ -z "$GET_channel" ]; 
+if [ -z "$GET_channel" ];
 then
-  echo "X-Channel-Override: 0"
+  echo -ne "X-Channel-Override: 0\r\n"
   GET_channel=0
 fi
 
-echo "X-Channel: $GET_channel"
+echo -ne "X-Channel: $GET_channel\r\n"
+echo -ne "Content-Type: image/jpeg\r\n\r\n"
 
-cmd jpeg "$GET_channel"
-
+cmd jpeg "$GET_channel" -n


### PR DESCRIPTION
Makes jpeg.cgi page compliant with HTTP/1.1 RFC2616 and RFC7230

"HTTP/1.1 defines the sequence CR LF as the end-of-line marker for all protocol elements except the entity-body"

This only had LF, and when used with nodejs and axios that page would fail to be retrieved and throw an HPE_INVALID_HEADER_TOKEN error. (other pages likely need that fix, but retrieving the image was most important and most useful, I personally use it with Scrypted, which then uses this as the camera snapshot in Apple Home app)

Added -n to echo to make it clearer for myself, which removes the otherwise automatically added LF

Header automatically added by cmd jpeg, were also missing the CR, but the cmd jpeg -n parameter allowed to remove those headers, so I added them manually above.

Tested with node.js v18.16.0, during my troubleshooting/research this seems to have become an issue after node.js v12