### PR TITLE
Improve webserver's compliance with http/1.1 specification 

### DIFF
--- a/SD_ROOT/wz_mini/www/cgi-bin/shared.cgi
+++ b/SD_ROOT/wz_mini/www/cgi-bin/shared.cgi
@@ -119,7 +119,7 @@ stringContain() { [ -z "${2##*$1*}" ] && [ -z "$1" -o -n "$2" ]; }
 
 test_area_access()
 {
-echo "search: $1"
+echo -ne "search: $1\r\n"
 values=$(cat "$base_hack_ini" | grep "WEB_SERVER_OPTIONS" | cut -f2 -d=  ) 
 
 


### PR DESCRIPTION
This PR improves the webserver's compliance with the http/1.1 specification. primarily the `jpeg.cgi`. 

Similar to https://github.com/gtxaspec/wz_mini_hacks/pull/538 (Thanks @Squirrelf), this manually adds return and newline escape sequences. 
Because `jpeg.cgi` depends on `shared.cgi`'s `test_area_access` function it too needed to be compliant in order to meet node http's very strict http/1.1 standards in order to work without erroring out.

This improves compatibility with Scrypted which uses node http.
