### PR TITLE
When compiling, copy demo.zip instead of moving

### DIFF
--- a/v2_install/compile_image.sh
+++ b/v2_install/compile_image.sh
@@ -31,7 +31,7 @@ mkdir v2_ro
 echo "check for local zip"
 if [ -f demo.zip ]; then
 	echo "local archive found"
-	mv demo.zip ./v2_ro/
+	cp demo.zip ./v2_ro/
 else
 	echo "local archive not found"
 	echo "downloading latest firmware"


### PR DESCRIPTION
Right now if you provide a `demo.zip`, it gets moved into `./v2_ro/` which is then deleted on cleanup. This makes it frustrating if you need to rerun the compilation (especially if part of it fails). Copy the `demo.zip` instead so that the command can be immediately re-run without copying the `demo.zip` back in place.