### PR TITLE
Update S09dnsmasq

### DIFF
--- a/SD_ROOT/wz_mini/etc/network.d/S09dnsmasq
+++ b/SD_ROOT/wz_mini/etc/network.d/S09dnsmasq
@@ -28,6 +28,7 @@ dnsmasq_launch() {
                 else
                 /opt/wz_mini/bin/dnsmasq -C /opt/wz_mini/etc/dnsmasq.conf
                 fi
+		sleep 3
 		rm -f /tmp/resolv.conf
 		cp /opt/wz_mini/etc/resolv.conf /tmp/resolv.conf
 		echo "dnsmasq enabled"

--- a/SD_ROOT/wz_mini/etc/network.d/S09dnsmasq
+++ b/SD_ROOT/wz_mini/etc/network.d/S09dnsmasq
@@ -17,7 +17,17 @@ dnsmasq_launch() {
 	if [[ "$ENABLE_LOCAL_DNS" == "true" ]]; then
                 echo "wait for resolv.conf creation from iCamera"
                 sleep 5
-		dnsmasq -C /opt/wz_mini/etc/dnsmasq.conf
+		#kill the system dnsmasq if present
+                dmon_pid=$(pgrep -f "dmon.*dnsmasq")
+                        if [ -n "$dmon_pid" ]; then
+                        kill $dmon_pid
+                        fi
+                #figure out if there is a system dnsmasq bin present and use that if so, otherwise use wz_mini's binary
+                if [ -f /system/bin/dnsmasq ]; then
+                /system/bin/dnsmasq -C /opt/wz_mini/etc/dnsmasq.conf &
+                else
+                /opt/wz_mini/bin/dnsmasq -C /opt/wz_mini/etc/dnsmasq.conf
+                fi
 		rm -f /tmp/resolv.conf
 		cp /opt/wz_mini/etc/resolv.conf /tmp/resolv.conf
 		echo "dnsmasq enabled"


### PR DESCRIPTION
Added logic to use the newly included dnsmasq process from Wyze on newer firmwares. First, the script will detect the newer dnsmasq process if present and kill it, next, it will determine if the newer dnsmasq binary IS present and start dnsmasq back up using our config from wz_mini. If not, it will simply launch wz_mini's build of dnsmasq. This effectively fixes the script for newer versions of the Wyze firmware.