### PR TITLE
go2rtc: Change log level from debug to error for ffmpeg

### DIFF
--- a/SD_ROOT/wz_mini/etc/go2rtc.yml
+++ b/SD_ROOT/wz_mini/etc/go2rtc.yml
@@ -1,7 +1,7 @@
 log:
   level: info # default level
   api: trace
-  exec: debug
+  exec: error
   ngrok: info
   rtsp: warn
   streams: error


### PR DESCRIPTION
Logging debug information for ffmpeg fills up the SD card and causes unnecessary wear when streaming 24/7.
Go2RTC can also crash due to excessive log size and insufficient storage space. This shouldn't be the default setting as it causes issues long-term, especially with small SD cards.

Changing the log level from debug to error resolves the issue.